### PR TITLE
docs: add Portuguese and Spanish READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,53 @@
+# PHP Learning Playground (PHP Scholar)
+
+Este es un prototipo de una herramienta interactiva para estudiantes de PHP, utilizando WebAssembly (**PHP-WASM**) para ejecutar código directamente en el navegador.
+
+## 🚀 Cómo Ejecutar
+
+1. Asegúrate de tener [Node.js](https://nodejs.org/) instalado.
+2. En el directorio del proyecto, instala las dependencias:
+   ```bash
+   npm install
+   ```
+3. Inicia el servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+4. Accede a `http://localhost:5173`.
+
+## 🛠️ Tecnologías Utilizadas
+
+- **@php-wasm/web-8-3**: El motor de PHP que funciona en WebAssembly.
+- **CodeMirror 6**: Editor de código moderno con soporte para PHP.
+- **Vite**: Herramienta de compilación rápida para el frontend.
+- **TypeScript**: Para una mejor experiencia de desarrollo y validación de errores.
+
+## 💡 Cómo funciona
+
+La herramienta carga el entorno de ejecución de PHP 8.3 a través de WASM. Cuando el estudiante hace clic en "Ejecutar" (o usa `Ctrl+Enter`), el código del editor es procesado por el motor de PHP, que evalúa el script y ejecuta los casos de prueba asociados.
+
+## 📂 Estructura del Proyecto
+
+- `index.html`: Estructura de la interfaz de usuario.
+- `src/style.css`: Estilo premium (Modo oscuro moderno).
+- `src/main.ts`: Lógica de integración entre PHP + Editor.
+- `src/ExerciseManager.ts`: Gestiona la carga y validación de ejercicios.
+- `public/exercises/`: Archivos Markdown que contienen las instrucciones y pruebas de los ejercicios.
+
+## 📚 Ejercicios Disponibles
+
+1. **Suma de Enteros** (`soma`): Conceptos básicos sobre funciones y suma.
+2. **Multiplicación de Enteros** (`multiplicar`): Conceptos básicos sobre funciones y multiplicación.
+3. **Navegación de Objetos** (`objetos`): Acceso a propiedades de objetos anidados con `->`.
+4. **Manejo de Arrays** (`arrays`): Adición de elementos a arreglos de PHP.
+5. **Clases y Objetos** (`classes`): Creación de clases, modificadores de acceso y métodos.
+6. **Manipulación de Strings** (`strings`): Uso de funciones nativas para invertir texto.
+
+## 🌐 Soporte Multilingüe
+
+El playground soporta:
+
+- 🇧🇷 Portugués (`/pt/` o `?lang=pt`)
+- 🇺🇸 Inglés (`/en/` o `?lang=en`)
+- 🇪🇸 Español (`/es/` o `?lang=es`)
+- 🇮🇹 Italiano (`/it/` o `?lang=it`)

--- a/README.md
+++ b/README.md
@@ -1,59 +1,53 @@
 # PHP Learning Playground (PHP Scholar)
 
-Este é um protótipo de uma ferramenta interativa para estudantes de PHP, utilizando WebAssembly (**PHP-WASM**) para executar código diretamente no navegador.
+This is a prototype of an interactive tool for PHP students, using WebAssembly (**PHP-WASM**) to execute code directly in the browser.
 
-## 🚀 Como Executar
+## 🚀 How to Run
 
-1. Certifique-se de ter o [Node.js](https://nodejs.org/) instalado.
-2. No diretório do projeto, instale as dependências:
+1. Make sure you have [Node.js](https://nodejs.org/) installed.
+2. In the project directory, install dependencies:
    ```bash
    npm install
    ```
-3. Inicie o servidor de desenvolvimento:
+3. Start the development server:
    ```bash
    npm run dev
    ```
-4. Acesse `http://localhost:5173`.
+4. Access `http://localhost:5173`.
 
-## 🛠️ Tecnologias Utilizadas
+## 🛠️ Technologies Used
 
-- **@php-wasm/web**: O motor PHP rodando em WebAssembly.
-- **CodeMirror 6**: Editor de código moderno com suporte a PHP.
-- **Vite**: Build tool rápida para o frontend.
-- **Vanilla JS**: Para manter o projeto leve e focado.
+- **@php-wasm/web-8-3**: The PHP engine running in WebAssembly.
+- **CodeMirror 6**: Modern code editor with PHP support.
+- **Vite**: Fast build tool for the frontend.
+- **TypeScript**: For better development experience and error validation.
 
-## 💡 Como funciona
+## 💡 How it works
 
-A ferramenta carrega o runtime do PHP 8.3 via WASM. Quando o estudante clica em "Executar" (ou usa `Ctrl+Enter`), o código do editor é enviado para o `php.runStream()`, que retorna o `stdout` e `stderr` do script.
+The tool loads the PHP 8.3 runtime via WASM. When the student clicks "Run" (or uses `Ctrl+Enter`), the editor's code is processed by the PHP engine, which evaluates the script and runs the associated test cases.
 
-### Versão para Node.js
+## 📂 Project Structure
 
-Embora o protótipo seja web, a biblioteca `@php-wasm/node` (citada na sua solicitação) funciona de forma quase idêntica:
+- `index.html`: UI structure.
+- `src/style.css`: Premium styling (Modern Dark Mode).
+- `src/main.ts`: Integration logic between PHP + Editor.
+- `src/ExerciseManager.ts`: Manages loading and validation of exercises.
+- `public/exercises/`: Markdown files containing exercise instructions and tests.
 
-```javascript
-import { PHP } from "@php-wasm/universal";
-import { loadNodeRuntime } from "@php-wasm/node";
+## 📚 Available Exercises
 
-async function run() {
-  const php = new PHP(await loadNodeRuntime("8.3"));
-  const result = await php.runStream({ code: '<?php echo "Olá!"; ?>' });
-  console.log(await result.stdoutText);
-}
-```
+1. **Sum of Integers** (`soma`): Basics about functions and addition.
+2. **Multiplication of Integers** (`multiplicar`): Basics about functions and multiplication.
+3. **Object Navigation** (`objetos`): Accessing nested object properties with `->`.
+4. **Handling Arrays** (`arrays`): Adding elements to PHP arrays.
+5. **Classes and Objects** (`classes`): Creating classes, access modifiers, and methods.
+6. **String Manipulation** (`strings`): Using native functions to reverse text.
 
-## 📂 Estrutura do Projeto
+## 🌐 Multilanguage Support
 
-- `index.html`: Estrutura da UI.
-- `src/style.css`: Estilização premium (Dark Mode).
-- `src/main.ts`: Lógica de integração PHP + Editor.
-- `src/ExerciseManager.ts`: Gerencia o carregamento e validação de exercícios.
-- `vite.config.ts`: Configurações necessárias para carregar arquivos `.so` e `.wasm`.
+The playground supports:
 
-## 📚 Exercícios Disponíveis
-
-1. **Soma de Inteiros** (`soma`): Básico sobre funções e soma.
-2. **Multiplicação de Inteiros** (`multiplicar`): Básico sobre funções e multiplicação.
-3. **Navegação em Objetos** (`objetos`): Acesso a propriedades de objetos aninhados com `->`.
-4. **Manipulando Arrays** (`arrays`): Adição de elementos em arrays PHP.
-5. **Classes e Objetos** (`classes`): Criação de classes, modificadores de acesso e métodos.
-6. **Manipulação de Strings** (`strings`): Uso de funções nativas para inverter textos.
+- 🇧🇷 Portuguese (`/pt/` or `?lang=pt`)
+- 🇺🇸 English (`/en/` or `?lang=en`)
+- 🇪🇸 Spanish (`/es/` or `?lang=es`)
+- 🇮🇹 Italian (`/it/` or `?lang=it`)

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,0 +1,59 @@
+# PHP Learning Playground (PHP Scholar)
+
+Este é um protótipo de uma ferramenta interativa para estudantes de PHP, utilizando WebAssembly (**PHP-WASM**) para executar código diretamente no navegador.
+
+## 🚀 Como Executar
+
+1. Certifique-se de ter o [Node.js](https://nodejs.org/) instalado.
+2. No diretório do projeto, instale as dependências:
+   ```bash
+   npm install
+   ```
+3. Inicie o servidor de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+4. Acesse `http://localhost:5173`.
+
+## 🛠️ Tecnologias Utilizadas
+
+- **@php-wasm/web**: O motor PHP rodando em WebAssembly.
+- **CodeMirror 6**: Editor de código moderno com suporte a PHP.
+- **Vite**: Build tool rápida para o frontend.
+- **Vanilla JS**: Para manter o projeto leve e focado.
+
+## 💡 Como funciona
+
+A ferramenta carrega o runtime do PHP 8.3 via WASM. Quando o estudante clica em "Executar" (ou usa `Ctrl+Enter`), o código do editor é enviado para o `php.runStream()`, que retorna o `stdout` e `stderr` do script.
+
+### Versão para Node.js
+
+Embora o protótipo seja web, a biblioteca `@php-wasm/node` (citada na sua solicitação) funciona de forma quase idêntica:
+
+```javascript
+import { PHP } from "@php-wasm/universal";
+import { loadNodeRuntime } from "@php-wasm/node";
+
+async function run() {
+  const php = new PHP(await loadNodeRuntime("8.3"));
+  const result = await php.runStream({ code: '<?php echo "Olá!"; ?>' });
+  console.log(await result.stdoutText);
+}
+```
+
+## 📂 Estrutura do Projeto
+
+- `index.html`: Estrutura da UI.
+- `src/style.css`: Estilização premium (Dark Mode).
+- `src/main.ts`: Lógica de integração PHP + Editor.
+- `src/ExerciseManager.ts`: Gerencia o carregamento e validação de exercícios.
+- `vite.config.ts`: Configurações necessárias para carregar arquivos `.so` e `.wasm`.
+
+## 📚 Exercícios Disponíveis
+
+1. **Soma de Inteiros** (`soma`): Básico sobre funções e soma.
+2. **Multiplicação de Inteiros** (`multiplicar`): Básico sobre funções e multiplicação.
+3. **Navegação em Objetos** (`objetos`): Acesso a propriedades de objetos aninhados com `->`.
+4. **Manipulando Arrays** (`arrays`): Adição de elementos em arrays PHP.
+5. **Classes e Objetos** (`classes`): Criação de classes, modificadores de acesso e métodos.
+6. **Manipulação de Strings** (`strings`): Uso de funções nativas para inverter textos.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
     target: "esnext",
     rollupOptions: {
       external: ["env", "wasi_snapshot_preview1", /^GOT\..*$/],
+      onwarn(warning, warn) {
+        if (warning.code === "EVAL" && warning.id?.includes("php-wasm")) return;
+        warn(warning);
+      },
     },
     commonjsOptions: {
       include: [/node_modules/],


### PR DESCRIPTION
This pull request adds comprehensive multilingual documentation for the PHP Learning Playground project and improves the development experience by refining build warnings. The main changes include new README files for Spanish and Portuguese, a complete rewrite and translation of the main `README.md` to English, and an update to the Vite build configuration to suppress irrelevant warnings.

**Documentation updates:**

* Added a new Spanish documentation file `README.es.md` with project overview, setup instructions, technologies, usage, project structure, exercise list, and language support.
* Added a new Portuguese documentation file `README.pt.md` with similar structure and content, tailored for Portuguese-speaking users.
* Rewrote `README.md` in English, translating and updating all sections for clarity and consistency, including setup, technologies, project structure, and exercises.

**Build and developer experience:**

* Updated `vite.config.ts` to suppress "EVAL" warnings related to `php-wasm` dependencies, reducing noise during development builds.