### PR TITLE
perf: optimize bundle size with manualChunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,11 +35,28 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    chunkSizeWarningLimit: 1000,
     rollupOptions: {
       external: ["env", "wasi_snapshot_preview1", /^GOT\..*$/],
       onwarn(warning, warn) {
         if (warning.code === "EVAL" && warning.id?.includes("php-wasm")) return;
         warn(warning);
+      },
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules")) {
+            if (id.includes("@codemirror") || id.includes("codemirror")) {
+              return "codemirror";
+            }
+            if (id.includes("marked") || id.includes("js-yaml")) {
+              return "parsers";
+            }
+            if (id.includes("@php-wasm")) {
+              return "php-wasm-bridge";
+            }
+            return "vendor";
+          }
+        },
       },
     },
     commonjsOptions: {


### PR DESCRIPTION
This pull request updates the Vite build configuration to optimize how JavaScript chunks are generated and to improve build warnings. The most important changes focus on customizing chunk splitting for better performance and maintainability.

Build optimization:

* Added a `manualChunks` function under `rollupOptions.output` in `vite.config.ts` to group dependencies into separate chunks: `codemirror`, `parsers`, `php-wasm-bridge`, and a general `vendor` chunk. This helps with caching and load performance.
* Increased the `chunkSizeWarningLimit` to 1000 in the build configuration to reduce unnecessary warnings for large chunks.